### PR TITLE
Completed previous commit

### DIFF
--- a/SS.Integration.Adapter/StreamListener.cs
+++ b/SS.Integration.Adapter/StreamListener.cs
@@ -978,7 +978,8 @@ namespace SS.Integration.Adapter
 
             Stop();
 
-            SuspendFixture(SuspensionReason.FIXTURE_DISPOSING);
+            if(!IsFixtureDeleted && !IsFixtureDeleted)
+                SuspendFixture(SuspensionReason.FIXTURE_DISPOSING);
 
             // free the resource instantiated by the SDK
             _resource = null;


### PR DESCRIPTION
- When a listener gets disposed, no suspension commands are generate if
  the fixture is deleted or is over
