### PR TITLE
Fix: Fixture.MatchStatus was set to string representation of MatchStatusEnum value

### DIFF
--- a/SS.Integration.Adapter/StreamListener.cs
+++ b/SS.Integration.Adapter/StreamListener.cs
@@ -1060,7 +1060,7 @@ namespace SS.Integration.Adapter
             else
             {
                 if (state != null)
-                    fixture.MatchStatus = state.MatchStatus.ToString();
+                    fixture.MatchStatus = ((int)state.MatchStatus).ToString();
 
                 try
                 {


### PR DESCRIPTION
When setting MatchStatus of a fixture, it should be as a numeric value as a string, example "40" for MatchStatus.InRunning.
In one instance it was done wrongly and the MatchStatus therefore got the enum as string
instead, example "InRunning" for MatchStatus.InRunning.
The enum must always first be casted to int, which was missed in this case.

Also adding an unittest that detects the error.
